### PR TITLE
Stylesheet for New Gauge Widgets

### DIFF
--- a/styleSheet/masterStyleSheet.qss
+++ b/styleSheet/masterStyleSheet.qss
@@ -673,7 +673,7 @@ HotCathodeGauge[state="ValidHi"] #icon {
 
 /*###################################*/
 
-/* Cold Cathode Combo Gauge - gcp */
+/* Cold Cathode Combo Gauge - gccc */
 
 ColdCathodeComboGauge #pressure{
     color: blue;
@@ -731,7 +731,7 @@ ColdCathodeComboGauge[state="ValidHi"] #icon {
 
 /*###################################*/
 
-/* Hot Cathode Combo Gauge - gcp */
+/* Hot Cathode Combo Gauge - ghcc */
 
 HotCathodeComboGauge #pressure{
     color: blue;
@@ -789,7 +789,7 @@ HotCathodeComboGauge[state="ValidHi"] #icon {
 
 /*###################################*/
 
-/* Capacitance Manometer Gauge - gcp */
+/* Capacitance Manometer Gauge - gcm */
 
 CapacitanceManometerGauge #pressure{
     color: blue;

--- a/styleSheet/masterStyleSheet.qss
+++ b/styleSheet/masterStyleSheet.qss
@@ -791,24 +791,24 @@ HotCathodeComboGauge[state="ValidHi"] #icon {
 
 /* Capacitance Monometer Gauge - gcp */
 
-CapacitanceMonometerGauge #pressure{
+CapacitanceManometerGauge #pressure{
     color: blue;
     border: 1px solid black;
     background-color : white
 }
-CapacitanceMonometerGauge[state="GaugeDisconnected"]  #pressure{
+CapacitanceManometerGauge[state="GaugeDisconnected"]  #pressure{
     color: gray;
     border: 1px;
 }
-CapacitanceMonometerGauge[state="Off"]  #pressure{
+CapacitanceManometerGauge[state="Off"]  #pressure{
     color: gray;
     border: 1px;
 }
-CapacitanceMonometerGauge[state="PressInvalid"]  #pressure{
+CapacitanceManometerGauge[state="PressInvalid"]  #pressure{
     color: gray;
     border: 1px;
 }
-CapacitanceMonometerGauge[interlocked="true"] #icon{
+CapacitanceManometerGauge[interlocked="true"] #icon{
     border: 2px solid black;
     qproperty-brush: black;
     border-top-left-radius: 9px;
@@ -816,31 +816,31 @@ CapacitanceMonometerGauge[interlocked="true"] #icon{
     border-bottom-left-radius: 9px;
     border-bottom-right-radius: 9px;
 }
-CapacitanceMonometerGauge[state="Off"] #icon {
+CapacitanceManometerGauge[state="Off"] #icon {
     qproperty-penColor: black;
     qproperty-brush: gray;
 }
-CapacitanceMonometerGauge[state="GaugeDisconnected"] #icon {
+CapacitanceManometerGauge[state="GaugeDisconnected"] #icon {
     qproperty-penColor: gray;
     qproperty-brush: black;
 }
-CapacitanceMonometerGauge[state="OoR"] #icon {
+CapacitanceManometerGauge[state="OoR"] #icon {
     qproperty-penColor: black;
     qproperty-brush: red;
 }
-CapacitanceMonometerGauge[state="PressInvalid"] #icon {
+CapacitanceManometerGauge[state="PressInvalid"] #icon {
     qproperty-penColor: black;
     qproperty-brush: gray;
 }
-CapacitanceMonometerGauge[state="Valid"] #icon {
+CapacitanceManometerGauge[state="Valid"] #icon {
     qproperty-penColor: black;
     qproperty-brush: #00FF00;
 }
-CapacitanceMonometerGauge[state="ValidLo"] #icon {
+CapacitanceManometerGauge[state="ValidLo"] #icon {
     qproperty-penColor: black;
     qproperty-brush: #00FF00;
 }
-CapacitanceMonometerGauge[state="ValidHi"] #icon {
+CapacitanceManometerGauge[state="ValidHi"] #icon {
     qproperty-penColor: black;
     qproperty-brush: #00FF00;
 }

--- a/styleSheet/masterStyleSheet.qss
+++ b/styleSheet/masterStyleSheet.qss
@@ -670,3 +670,177 @@ HotCathodeGauge[state="ValidHi"] #icon {
     qproperty-penColor: black;
     qproperty-brush: #00FF00;
 }
+
+/*###################################*/
+
+/* Cold Cathode Combo Gauge - gcp */
+
+ColdCathodeComboGauge #pressure{
+    color: blue;
+    border: 1px solid black;
+    background-color : white
+}
+ColdCathodeComboGauge[state="GaugeDisconnected"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+ColdCathodeComboGauge[state="Off"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+ColdCathodeComboGauge[state="PressInvalid"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+ColdCathodeComboGauge[interlocked="true"] #icon{
+    border: 2px solid black;
+    qproperty-brush: black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+ColdCathodeComboGauge[state="Off"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+ColdCathodeComboGauge[state="GaugeDisconnected"] #icon {
+    qproperty-penColor: gray;
+    qproperty-brush: black;
+}
+ColdCathodeComboGauge[state="OoR"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+ColdCathodeComboGauge[state="PressInvalid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+ColdCathodeComboGauge[state="Valid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+ColdCathodeComboGauge[state="ValidLo"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+ColdCathodeComboGauge[state="ValidHi"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+
+/*###################################*/
+
+/* Hot Cathode Combo Gauge - gcp */
+
+HotCathodeComboGauge #pressure{
+    color: blue;
+    border: 1px solid black;
+    background-color : white
+}
+HotCathodeComboGauge[state="GaugeDisconnected"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+HotCathodeComboGauge[state="Off"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+HotCathodeComboGauge[state="PressInvalid"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+HotCathodeComboGauge[interlocked="true"] #icon{
+    border: 2px solid black;
+    qproperty-brush: black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+HotCathodeComboGauge[state="Off"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+HotCathodeComboGauge[state="GaugeDisconnected"] #icon {
+    qproperty-penColor: gray;
+    qproperty-brush: black;
+}
+HotCathodeComboGauge[state="OoR"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+HotCathodeComboGauge[state="PressInvalid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+HotCathodeComboGauge[state="Valid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+HotCathodeComboGauge[state="ValidLo"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+HotCathodeComboGauge[state="ValidHi"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+
+/*###################################*/
+
+/* Capacitance Monometer Gauge - gcp */
+
+CapacitanceMonometerGauge #pressure{
+    color: blue;
+    border: 1px solid black;
+    background-color : white
+}
+CapacitanceMonometerGauge[state="GaugeDisconnected"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+CapacitanceMonometerGauge[state="Off"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+CapacitanceMonometerGauge[state="PressInvalid"]  #pressure{
+    color: gray;
+    border: 1px;
+}
+CapacitanceMonometerGauge[interlocked="true"] #icon{
+    border: 2px solid black;
+    qproperty-brush: black;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    border-bottom-left-radius: 9px;
+    border-bottom-right-radius: 9px;
+}
+CapacitanceMonometerGauge[state="Off"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+CapacitanceMonometerGauge[state="GaugeDisconnected"] #icon {
+    qproperty-penColor: gray;
+    qproperty-brush: black;
+}
+CapacitanceMonometerGauge[state="OoR"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: red;
+}
+CapacitanceMonometerGauge[state="PressInvalid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: gray;
+}
+CapacitanceMonometerGauge[state="Valid"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+CapacitanceMonometerGauge[state="ValidLo"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}
+CapacitanceMonometerGauge[state="ValidHi"] #icon {
+    qproperty-penColor: black;
+    qproperty-brush: #00FF00;
+}

--- a/styleSheet/masterStyleSheet.qss
+++ b/styleSheet/masterStyleSheet.qss
@@ -789,7 +789,7 @@ HotCathodeComboGauge[state="ValidHi"] #icon {
 
 /*###################################*/
 
-/* Capacitance Monometer Gauge - gcp */
+/* Capacitance Manometer Gauge - gcp */
 
 CapacitanceManometerGauge #pressure{
     color: blue;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Adding stylesheets for three new gauge widgets. The style sheets are copied over from the rough gauge.
<!--- Describe your changes in detail -->

## Motivation and Context
We are currently using the rough gauge widget for combo and capacitance manometer gauges. To remedy the confusion this causes, we have made new gauge widgets. Everything between these widgets and the old rough gauge widget are the same, except for the icon. Hence, the stylesheets can just be copied over.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Interactively in designer
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
![image-2025-04-03-11-21-56-746](https://github.com/user-attachments/assets/eba5def4-a92b-40de-b88c-edbd85625222)

-->
